### PR TITLE
Add functionality for ignoring notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ You just need to add tests as shown below & treon would execute them and report 
 
 ![](images/doctest.png)
 
+## Ignoring notebooks
+
+You can ignore notebooks by creating a `.treonignore` file. To skip notebooks
+during testing, you can specify the relative path to a notebook, a directory,
+or a glob (kind of like a `.gitignore` file).
+
+You can have multiple `.treonignore` files. The rules in each `.treonignore`
+file will apply recursively to each child subdirectory.
+
+`.treonignore` rules will not be considered if you specify a path to a notebook
+(and not a directory).
+
 ## Note about dependencies
 * You need to run treon from environment (virtualenv/pipenv etc.) that has all the dependcies required for Notebooks under test
 * treon only works with python3+ environments and uses python3 kernel for executing notebooks

--- a/tests/resources/nested/nested_again/empty.ipynb
+++ b/tests/resources/nested/nested_again/empty.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook intentionally left blank."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 import contextlib
+import glob
 import pathlib
 
 from treon.treon import build_ignore_list
@@ -38,9 +39,9 @@ def test_path_ignore_absolute():
 
 def test_path_ignore_dir():
     with _temporary_treonignore('/') as ignored:
-        assert len(ignored) == len(list(TEST_NOTEBOOK_PATH.iterdir()))
+        assert len(ignored) == len(glob.glob(TEST_NOTEBOOK_PATH.joinpath('**.ipynb').as_posix()))
 
 
 def test_glob_ignore():
     with _temporary_treonignore('*') as ignored:
-        assert len(ignored) == len(list(TEST_NOTEBOOK_PATH.iterdir()))
+        assert len(ignored) == len(glob.glob(TEST_NOTEBOOK_PATH.joinpath('**.ipynb').as_posix()))

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -1,0 +1,36 @@
+# -*- encoding: utf-8 -*-
+import contextlib
+import pathlib
+
+from treon.treon import build_ignore_list
+
+
+TEST_NOTEBOOK_PATH = pathlib.Path(__file__).parent.joinpath('resources')
+
+
+@contextlib.contextmanager
+def _temporary_treonignore(*rules):
+    ignorefile = TEST_NOTEBOOK_PATH.joinpath('.treonignore')
+    try:
+        ignorefile.touch(exist_ok=False)
+        ignorefile.write_text('\n'.join(rules))
+        yield
+    finally:
+        ignorefile.unlink()
+
+
+def test_no_ignore():
+    with _temporary_treonignore():
+        assert build_ignore_list(TEST_NOTEBOOK_PATH) == []
+
+def test_path_ignore():
+    with _temporary_treonignore('basic.ipynb'):
+        ignored = build_ignore_list(TEST_NOTEBOOK_PATH)
+        assert len(ignored) == 1
+        assert TEST_NOTEBOOK_PATH.joinpath('basic.ipynb').samefile(ignored[0])
+
+
+def test_glob_ignore():
+    with _temporary_treonignore('*'):
+        ignored = build_ignore_list(TEST_NOTEBOOK_PATH)
+        assert len(ignored) == len(list(TEST_NOTEBOOK_PATH.iterdir()))

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -30,6 +30,13 @@ def test_path_ignore():
         assert TEST_NOTEBOOK_PATH.joinpath('basic.ipynb').samefile(ignored[0])
 
 
+def test_path_ignore_absolute():
+    with _temporary_treonignore('/basic.ipynb'):
+        ignored = build_ignore_list(TEST_NOTEBOOK_PATH)
+        assert len(ignored) == 1
+        assert TEST_NOTEBOOK_PATH.joinpath('basic.ipynb').samefile(ignored[0])
+
+
 def test_glob_ignore():
     with _temporary_treonignore('*'):
         ignored = build_ignore_list(TEST_NOTEBOOK_PATH)

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -14,30 +14,33 @@ def _temporary_treonignore(*rules):
     try:
         ignorefile.touch(exist_ok=False)
         ignorefile.write_text('\n'.join(rules))
-        yield
+        yield list(build_ignore_list(TEST_NOTEBOOK_PATH))
     finally:
         ignorefile.unlink()
 
 
 def test_no_ignore():
-    with _temporary_treonignore():
-        assert build_ignore_list(TEST_NOTEBOOK_PATH) == []
+    with _temporary_treonignore() as ignored:
+        assert ignored == []
+
 
 def test_path_ignore():
-    with _temporary_treonignore('basic.ipynb'):
-        ignored = build_ignore_list(TEST_NOTEBOOK_PATH)
+    with _temporary_treonignore('basic.ipynb') as ignored:
         assert len(ignored) == 1
         assert TEST_NOTEBOOK_PATH.joinpath('basic.ipynb').samefile(ignored[0])
 
 
 def test_path_ignore_absolute():
-    with _temporary_treonignore('/basic.ipynb'):
-        ignored = build_ignore_list(TEST_NOTEBOOK_PATH)
+    with _temporary_treonignore('/basic.ipynb') as ignored:
         assert len(ignored) == 1
         assert TEST_NOTEBOOK_PATH.joinpath('basic.ipynb').samefile(ignored[0])
 
 
+def test_path_ignore_dir():
+    with _temporary_treonignore('/') as ignored:
+        assert len(ignored) == len(list(TEST_NOTEBOOK_PATH.iterdir()))
+
+
 def test_glob_ignore():
-    with _temporary_treonignore('*'):
-        ignored = build_ignore_list(TEST_NOTEBOOK_PATH)
+    with _temporary_treonignore('*') as ignored:
         assert len(ignored) == len(list(TEST_NOTEBOOK_PATH.iterdir()))

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -117,11 +117,12 @@ def get_notebooks_to_test(args):
         LOG.info("Recursively scanning %s for notebooks...", path)
         ignored = build_ignore_list(path)
         notebooks = filter(lambda nb: nb not in ignored, path.glob('**/*.ipynb'))
+        notebooks = list((nb.as_posix() for nb in notebooks))
+        if len(notebooks) == 0:
+            sys.exit("No notebooks to test in {path}".format(path=path))
         return (nb.as_posix() for nb in notebooks)
     else:
         sys.exit("{path} is not a valid path".format(path=path))
-
-    sys.exit("No notebooks to test in {path}".format(path=path))
 
 
 def build_ignore_list(search_directory):

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -112,16 +112,16 @@ def get_notebooks_to_test(args):
     if path.is_file():
         if path.suffix == '.ipynb':
             return [path.as_posix()]
-        sys.exit(f"{path} is not a notebook")
+        sys.exit("{path} is not a notebook".format(path=path))
     elif path.is_dir():
         LOG.info("Recursively scanning %s for notebooks...", path)
         ignored = build_ignore_list(path)
         notebooks = filter(lambda nb: nb not in ignored, path.glob('**/*.ipynb'))
         return (nb.as_posix() for nb in notebooks)
     else:
-        sys.exit(f"{path} is not a valid path")
+        sys.exit("{path} is not a valid path".format(path=path))
 
-    sys.exit(f"No notebooks to test in {path}")
+    sys.exit("No notebooks to test in {path}".format(path=path))
 
 
 def build_ignore_list(search_directory):

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -32,7 +32,6 @@ from .task import Task
 DEFAULT_THREAD_COUNT = 10
 
 LOG = logging.getLogger('treon')
-LOG.setLevel(logging.DEBUG)
 
 
 def main():

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -143,11 +143,12 @@ def build_ignore_list(search_directory):
         with ignorefile.open() as rules:
             for rule in rules:
                 rule = rule.strip().lstrip(os.sep)
+                rule = ignorefile.parent.joinpath(rule).as_posix()
                 # And find any notebooks that match those rules.
-                if os.path.isdir(ignorefile.parent.joinpath(rule)):
+                if os.path.isdir(rule):
                     rule = os.path.join(rule, '**')
                 LOG.debug("Adding ignore rule %s", rule)
-                for match in glob.iglob(ignorefile.parent.joinpath(rule).as_posix()):
+                for match in glob.iglob(rule):
                     if match.endswith('.ipynb'):
                         LOG.debug("Ignore file %s matches %r",
                                   ignorefile.as_posix(), match)

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -128,13 +128,19 @@ def build_ignore_list(search_directory):
     """
     Recursively searches a given directory for `.treonignore` files and
     compiles a list of :class:`pathlib.Path` objects that should be ignored.
+    Note that this function does not return the rules specified in any
+    `.treonignore` files but instead paths to the notebooks that should
+    be ignored once the parsed rules are applied.
 
     :param pathlib.Path search_directory: directory to search
     """
     globs = []
+    # For each .treonignore file in search_directory or its children...
     for ignorefile in search_directory.glob('**/.treonignore'):
         LOG.debug("Found ignore file %s", ignorefile.as_posix())
+        # Iterate over all of the rules in the .treonignore file...
         with ignorefile.open() as rules:
             for rule in rules:
+                # And find any notebooks that match those rules.
                 globs.extend(ignorefile.parent.glob(rule))
     return globs

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -18,19 +18,21 @@ Options:
 __version__ = "0.1.2"
 
 
-from docopt import docopt, DocoptExit
+import glob
 import logging
-from multiprocessing.dummy import Pool as ThreadPool
 import pathlib
 import os
 import sys
 import textwrap
+from multiprocessing.dummy import Pool as ThreadPool
+from docopt import docopt, DocoptExit
 
 from .task import Task
 
 DEFAULT_THREAD_COUNT = 10
 
 LOG = logging.getLogger('treon')
+LOG.setLevel(logging.DEBUG)
 
 
 def main():
@@ -146,7 +148,8 @@ def build_ignore_list(search_directory):
                 if os.path.isdir(ignorefile.parent.joinpath(rule)):
                     rule = os.path.join(rule, '**')
                 LOG.debug("Adding ignore rule %s", rule)
-                for match in ignorefile.parent.glob(rule):
-                    LOG.debug("Ignore file %s matches %r",
-                              ignorefile.as_posix(), match.as_posix())
-                    yield match
+                for match in glob.iglob(ignorefile.parent.joinpath(rule).as_posix()):
+                    if match.endswith('.ipynb'):
+                        LOG.debug("Ignore file %s matches %r",
+                                  ignorefile.as_posix(), match)
+                        yield match

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -118,7 +118,7 @@ def get_notebooks_to_test(args):
         ignored = build_ignore_list(path)
         notebooks = filter(lambda nb: nb not in ignored, path.glob('**/*.ipynb'))
         notebooks = list((nb.as_posix() for nb in notebooks))
-        if len(notebooks) == 0:
+        if not notebooks:
             sys.exit("No notebooks to test in {path}".format(path=path))
         return (nb.as_posix() for nb in notebooks)
     else:

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -112,8 +112,7 @@ def get_notebooks_to_test(args):
 
     if os.path.isdir(path):
         LOG.info('Recursively scanning %s for notebooks...', path)
-        path = os.path.join(path, '')  # adds trailing slash (/) if it's missing
-        glob_path = path + '**/*.ipynb'
+        path = os.path.join(path, '**/*.ipynb')
         result = glob.glob(glob_path, recursive=True)
     elif os.path.isfile(path):
         if path.lower().endswith('.ipynb'):

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -18,13 +18,14 @@ Options:
 __version__ = "0.1.2"
 
 
-import sys
-import os
-import logging
-import textwrap
-import pathlib
-from multiprocessing.dummy import Pool as ThreadPool
 from docopt import docopt, DocoptExit
+import glob
+import logging
+from multiprocessing.dummy import Pool as ThreadPool
+import pathlib
+import os
+import sys
+import textwrap
 
 from .task import Task
 
@@ -120,7 +121,7 @@ def get_notebooks_to_test(args):
         notebooks = list((nb.as_posix() for nb in notebooks))
         if not notebooks:
             sys.exit("No notebooks to test in {path}".format(path=path))
-        return (nb.as_posix() for nb in notebooks)
+        return notebooks
     else:
         sys.exit("{path} is not a valid path".format(path=path))
 
@@ -142,6 +143,7 @@ def build_ignore_list(search_directory):
         # Iterate over all of the rules in the .treonignore file...
         with ignorefile.open() as rules:
             for rule in rules:
+                rule = rule.strip().lstrip('/')
                 # And find any notebooks that match those rules.
                 globs.extend(ignorefile.parent.glob(rule))
     return globs


### PR DESCRIPTION
Closes #1. Allows ignoring notebooks with a `.treonignore` file. It mimics how `.gitignore` files work, except a little simpler.