### PR TITLE
Set working directory to the folder containing the notebook (fixes #12)

### DIFF
--- a/tests/resources/basic.ipynb
+++ b/tests/resources/basic.ipynb
@@ -11,6 +11,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import utils  # Test notebook-relative import\n",
+    "assert utils.guess_number() == 42"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [
@@ -83,7 +93,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/tests/resources/utils.py
+++ b/tests/resources/utils.py
@@ -1,0 +1,6 @@
+# -*- encoding: utf-8 -*-
+
+
+def guess_number():
+    """If notebooks can import this function, the Python path is set up correctly"""
+    return 42

--- a/treon/test_execution.py
+++ b/treon/test_execution.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 import nbformat
 
@@ -9,8 +10,14 @@ def execute_notebook(path):
     notebook = nbformat.read(path, as_version=4)
     notebook.cells.extend([unittest_cell(), doctest_cell()])
     processor = ExecutePreprocessor(timeout=-1, kernel_name='python3')
-    processor.preprocess(notebook, {'metadata': {'path': '.'}})
+    processor.preprocess(notebook, metadata(path))
     return parse_test_result(notebook.cells)
+
+
+def metadata(path):
+    return {'metadata': {
+        'path': os.path.dirname(path)
+    }}
 
 
 def parse_test_result(cells):


### PR DESCRIPTION
As per discussion in #12, and this [comment](https://github.com/jupyter/notebook/issues/2341#issuecomment-290138391), treon should have the same behavior as Jupyter, and use the notebooks' folder as working directory. This fixes priorly broken notebook-relative Python imports, and notebooks trying to read resources / data using notebook-relative file paths, in case the working directory of invoking treon did not match the directory containing the notebook.