### PR TITLE
Add option to exclude files from testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,19 @@ TEST RESULT
 ```
 Usage:
   treon
-  treon [PATH] [--threads=<number>] [-v]
+  treon [PATH] [--threads=<number>] [-v] [--exclude=<string>]...
 
 Arguments:
   PATH                File or directory path to find notebooks to test. Searches recursively for directory paths. [default: current working directory]
 
 Options:
   --threads=<number>  Number of parallel threads. Each thread processes one notebook file at a time. [default: 10]
+  -e=<string> --exclude=<string>   Option for excluding files or entire directories from testing. All files whose
+                      absolute path starts with the specified string are excluded from testing. This option can be
+                      specified more than once to exclude multiple files or directories.
   -v --verbose        Print detailed output for debugging.
   -h --help           Show this screen.
   --version           Show version.
-
 ```
 
 ## unitttest example

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Options:
   --threads=<number>  Number of parallel threads. Each thread processes one notebook file at a time. [default: 10]
   -e=<path> --exclude=<path>   Option for excluding files or entire directories from testing. All files whose
                       absolute path starts with the specified string are excluded from testing. This option can be
-                      specified more than once to exclude multiple files or directories.
+                      specified more than once to exclude multiple files or directories. If the exclude path is 
+                      a valid directory name, only this directory is excluded. Example: --exclude "./notebook" will not 
+                      exclude the folder "./notebook2" if "./notebook" is an existing directory.
   -v --verbose        Print detailed output for debugging.
   -h --help           Show this screen.
   --version           Show version.

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ TEST RESULT
 ```
 Usage:
   treon
-  treon [PATH] [--threads=<number>] [-v] [--exclude=<string>]...
+  treon [PATH] [--threads=<number>] [-v] [--exclude=<path>]...
 
 Arguments:
   PATH                File or directory path to find notebooks to test. Searches recursively for directory paths. [default: current working directory]
 
 Options:
   --threads=<number>  Number of parallel threads. Each thread processes one notebook file at a time. [default: 10]
-  -e=<string> --exclude=<string>   Option for excluding files or entire directories from testing. All files whose
+  -e=<path> --exclude=<path>   Option for excluding files or entire directories from testing. All files whose
                       absolute path starts with the specified string are excluded from testing. This option can be
                       specified more than once to exclude multiple files or directories.
   -v --verbose        Print detailed output for debugging.

--- a/tests/test_treon.py
+++ b/tests/test_treon.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 from treon import treon
 
 def test_filter_results_file():
@@ -44,6 +45,26 @@ def test_filter_results_empty():
 def test_filter_results_homedir():
     args = {"--exclude": ['~/resources']}
     results = [os.path.join(os.path.expanduser("~"), "resources/basic.ipynb")]
+    filtered = treon.filter_results(results=results, args=args)
+    expected = []
+    assert filtered == expected
+
+
+@mock.patch('os.path.isdir')
+def test_filter_results_exclude_is_dir(mock_isdir):
+    mock_isdir.return_value = True
+    args = {"--exclude": ["./notebook"]}
+    results = ["./notebook/1.pynb", "./notebook2/1.pynb"]
+    filtered = treon.filter_results(results=results, args=args)
+    expected = ["./notebook2/1.pynb"]
+    assert filtered == expected
+
+
+@mock.patch('os.path.isdir')
+def test_filter_results_exclude_is_not_dir(mock_isdir):
+    mock_isdir.return_value = False
+    args = {"--exclude": ["./notebook"]}
+    results = ["./notebook1/1.pynb", "./notebook2/1.pynb"]
     filtered = treon.filter_results(results=results, args=args)
     expected = []
     assert filtered == expected

--- a/tests/test_treon.py
+++ b/tests/test_treon.py
@@ -1,7 +1,7 @@
 from treon import treon
 
 
-def test_filter_results():
+def test_filter_results_file():
     args = {
         "--exclude": ['resources/basic.ipynb',
                       'failed']
@@ -19,14 +19,22 @@ def test_filter_results():
                 'other/resources.ipynb']
     assert filtered == expected
 
-    args = {
-        "--exclude": ['resources']
-    }
+
+def test_filter_results_folder():
+    args = {"--exclude": ['resources']}
+    results = ['resources/basic.ipynb',
+               'resources/doctest_failed.ipynb',
+               'resources/runtime_error.ipynb',
+               'resources/unittest_failed.ipynb',
+               'other/resources.ipynb']
 
     filtered = treon.filter_results(results=results, args=args)
     expected = ['other/resources.ipynb']
     assert filtered == expected
 
+
+def test_filter_results_empty():
+    args = {"--exclude": ['resources']}
     results = ['resources/basic.ipynb']
     filtered = treon.filter_results(results=results, args=args)
     expected = []

--- a/tests/test_treon.py
+++ b/tests/test_treon.py
@@ -1,0 +1,33 @@
+from treon import treon
+
+
+def test_filter_results():
+    args = {
+        "--exclude": ['resources/basic.ipynb',
+                      'failed']
+    }
+    results = ['resources/basic.ipynb',
+               'resources/doctest_failed.ipynb',
+               'resources/runtime_error.ipynb',
+               'resources/unittest_failed.ipynb',
+               'other/resources.ipynb']
+
+    filtered = treon.filter_results(results=results, args=args)
+    expected = ['resources/doctest_failed.ipynb',
+                'resources/runtime_error.ipynb',
+                'resources/unittest_failed.ipynb',
+                'other/resources.ipynb']
+    assert filtered == expected
+
+    args = {
+        "--exclude": ['resources']
+    }
+
+    filtered = treon.filter_results(results=results, args=args)
+    expected = ['other/resources.ipynb']
+    assert filtered == expected
+
+    results = ['resources/basic.ipynb']
+    filtered = treon.filter_results(results=results, args=args)
+    expected = []
+    assert filtered == expected

--- a/tests/test_treon.py
+++ b/tests/test_treon.py
@@ -1,5 +1,5 @@
 from treon import treon
-
+import os
 
 def test_filter_results_file():
     args = {
@@ -36,6 +36,14 @@ def test_filter_results_folder():
 def test_filter_results_empty():
     args = {"--exclude": ['resources']}
     results = ['resources/basic.ipynb']
+    filtered = treon.filter_results(results=results, args=args)
+    expected = []
+    assert filtered == expected
+
+
+def test_filter_results_homedir():
+    args = {"--exclude": ['~/resources']}
+    results = [os.path.join(os.path.expanduser("~"), "resources/basic.ipynb")]
     filtered = treon.filter_results(results=results, args=args)
     expected = []
     assert filtered == expected

--- a/tests/test_treon.py
+++ b/tests/test_treon.py
@@ -1,5 +1,5 @@
-from treon import treon
 import os
+from treon import treon
 
 def test_filter_results_file():
     args = {

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -9,7 +9,9 @@ Arguments:
 
 Options:
   --threads=<number>  Number of parallel threads. Each thread processes one notebook file at a time. [default: 10]
-  -e=<string> --exclude=<string>   Option for excluding files that start with this string. Can be provided more than once.
+  -e=<string> --exclude=<string>   Option for excluding files or entire directories from testing. All files whose
+                      absolute path starts with the specified string are excluded from testing. This option can be
+                      specified more than once to exclude multiple files or directories.
   -v --verbose        Print detailed output for debugging.
   -h --help           Show this screen.
   --version           Show version.
@@ -109,7 +111,8 @@ def print_test_collection(notebooks):
 
 def filter_results(results, args):
     for exclude_str in args['--exclude']:
-        results = [file for file in results if not file.startswith(exclude_str)]
+        exclude_abs = os.path.abspath(exclude_str)
+        results = [file for file in results if not os.path.abspath(file).startswith(exclude_abs)]
     return results
 
 

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -111,7 +111,7 @@ def print_test_collection(notebooks):
 
 def filter_results(results, args):
     for exclude_str in args['--exclude']:
-        exclude_abs = os.path.abspath(exclude_str)
+        exclude_abs = os.path.abspath(os.path.expanduser(exclude_str))
         results = [file for file in results if not os.path.abspath(file).startswith(exclude_abs)]
     return results
 

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -9,7 +9,7 @@ Arguments:
 
 Options:
   --threads=<number>  Number of parallel threads. Each thread processes one notebook file at a time. [default: 10]
-  -e=<string> --exclude=<string>   Pattern for excluding files from notebook search (substring matching)
+  -e=<string> --exclude=<string>   Option for excluding files that start with this string. Can be provided more than once.
   -v --verbose        Print detailed output for debugging.
   -h --help           Show this screen.
   --version           Show version.
@@ -107,6 +107,12 @@ def print_test_collection(notebooks):
     LOG.debug(message)
 
 
+def filter_results(results, args):
+    for exclude_str in args['--exclude']:
+        results = [file for file in results if not file.startswith(exclude_str)]
+    return results
+
+
 def get_notebooks_to_test(args):
     path = args['PATH'] or os.getcwd()
     result = []
@@ -128,6 +134,4 @@ def get_notebooks_to_test(args):
     if not result:
         sys.exit('No notebooks to test in {path}'.format(path=path))
 
-    for exclude_str in args['--exclude']:
-        result = [file for file in result if exclude_str not in file]
-    return result
+    return filter_results(result, args)

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -11,7 +11,9 @@ Options:
   --threads=<number>  Number of parallel threads. Each thread processes one notebook file at a time. [default: 10]
   -e=<string> --exclude=<string>   Option for excluding files or entire directories from testing. All files whose
                       absolute path starts with the specified string are excluded from testing. This option can be
-                      specified more than once to exclude multiple files or directories.
+                      specified more than once to exclude multiple files or directories. If the exclude path is
+                      a valid directory name, only this directory is excluded. Example: --exclude "./notebook" will not
+                      exclude the folder "./notebook2" if "./notebook" is an existing directory.
   -v --verbose        Print detailed output for debugging.
   -h --help           Show this screen.
   --version           Show version.
@@ -112,6 +114,8 @@ def print_test_collection(notebooks):
 def filter_results(results, args):
     for exclude_str in args['--exclude']:
         exclude_abs = os.path.abspath(os.path.expanduser(exclude_str))
+        if os.path.isdir(exclude_abs):
+            exclude_abs += os.sep
         results = [file for file in results if not os.path.abspath(file).startswith(exclude_abs)]
     return results
 

--- a/treon/treon.py
+++ b/treon/treon.py
@@ -2,13 +2,14 @@
 """
 Usage:
   treon
-  treon [PATH] [--threads=<number>] [-v]
+  treon [PATH] [--threads=<number>] [-v] [--exclude=<string>]...
 
 Arguments:
   PATH                File or directory path to find notebooks to test. Searches recursively for directory paths. [default: current working directory]
 
 Options:
   --threads=<number>  Number of parallel threads. Each thread processes one notebook file at a time. [default: 10]
+  -e=<string> --exclude=<string>   Pattern for excluding files from notebook search (substring matching)
   -v --verbose        Print detailed output for debugging.
   -h --help           Show this screen.
   --version           Show version.
@@ -127,4 +128,6 @@ def get_notebooks_to_test(args):
     if not result:
         sys.exit('No notebooks to test in {path}'.format(path=path))
 
+    for exclude_str in args['--exclude']:
+        result = [file for file in result if exclude_str not in file]
     return result


### PR DESCRIPTION
As described in #1, there is currently no way to exclude files from testing.
This pull request implements a simple way of excluding files from the command line via substring matching.