### PR TITLE
enable cell number print when verbose logging activates

### DIFF
--- a/treon/task.py
+++ b/treon/task.py
@@ -22,7 +22,7 @@ class Task:
         LOG.info("Triggered test for %s", self.file_path)
 
         try:
-            self.is_successful, console_output = execute_notebook(self.file_path)
+            self.is_successful, console_output = execute_notebook(self.file_path, _is_verbose())
             result = self.result_string()
 
             if not self.is_successful or _is_verbose():

--- a/treon/test_execution.py
+++ b/treon/test_execution.py
@@ -1,15 +1,22 @@
 import os
+import logging
 import textwrap
 import nbformat
 
 from nbformat.v4 import new_code_cell
 from nbconvert.preprocessors import ExecutePreprocessor
 
+LOG = logging.getLogger('treon.task')
 
-def execute_notebook(path):
+def execute_notebook(path, verbose=False):
     notebook = nbformat.read(path, as_version=4)
     notebook.cells.extend([unittest_cell(), doctest_cell()])
     processor = ExecutePreprocessor(timeout=-1, kernel_name='python3')
+
+    if verbose:
+        def print_executed_cell_index(cell, cell_index):
+            LOG.debug(f"Start executing cell {cell_index}")
+        processor.on_cell_start = print_executed_cell_index
     processor.preprocess(notebook, metadata(path))
     return parse_test_result(notebook.cells)
 


### PR DESCRIPTION
add info about which cell executed in verbose logs, in some cases this info helpful for search source of Kernel Died error which does not have a lot of logs...